### PR TITLE
Make l2 block parsing be compatible with ecotone attributes

### DIFF
--- a/apply_batch.py
+++ b/apply_batch.py
@@ -53,7 +53,7 @@ class PayloadApplier:
         with open(os.path.join(self.payload_dir, f'{hex(block_number)}.json'), 'r') as f:
             payload = json.load(f)
         is_canyon = int(payload['timestamp'], 16) >= self.canyon_time
-        send_json_rpc(self.engine_url, f'engine_newPayloadV{2 if is_canyon else 1}', params=[payload], token=self.jwt_token)
+        send_json_rpc(self.engine_url, f'engine_newPayloadV{2 if is_canyon else 1}', params=payload, token=self.jwt_token)
 
         if block_number < self.end and block_number % self.batch_size < self.batch_size - 1:
             return

--- a/build_payloads.py
+++ b/build_payloads.py
@@ -17,11 +17,12 @@ pp = pprint.PrettyPrinter(indent=2)
 L1_INFO_TX_TYPES = ['uint64', 'uint64', 'uint256', 'bytes32', 'uint64', 'bytes32', 'uint256', 'uint256']
 
 class PayloadBuilder:
-    def __init__(self, payload_dir, l1_rpc_urls, l2_rpc_urls, canyon_time, logging=False):
+    def __init__(self, payload_dir, l1_rpc_urls, l2_rpc_urls, canyon_time, ecotone_block_number, logging=False):
         self.payload_dir = payload_dir
         self.l1_rpc_urls = l1_rpc_urls
         self.l2_rpc_urls = l2_rpc_urls
         self.canyon_time = canyon_time
+        self.ecotone_block_number = ecotone_block_number
         self.logging = logging
 
     def _get_l1_rpc_url(self):
@@ -54,14 +55,17 @@ class PayloadBuilder:
 
         # 1. get block from l2
         l2_block = send_json_rpc(l2_rpc_url, RPCMethod.GetBlockByNumber, params=[l2_block_number, True])
+        txInput = l2_block['transactions'][0]['input']
+        if n > self.ecotone_block_number:
+            l1_block_number = hex(int.from_bytes(bytes.fromhex(txInput[2:])[28:36], 'big'))
+        else:
+            # 2. get l1 block number
+            l1_block_number = eth_abi.decode(L1_INFO_TX_TYPES, bytes.fromhex(txInput[10:]))[0]
 
-        # 2. get l1 block number
-        l1_block_number = eth_abi.decode(L1_INFO_TX_TYPES, bytes.fromhex(l2_block['transactions'][0]['input'][10:]))[0]
-
+        l1_rpc_url = self._get_l1_rpc_url()
         # 3. get l1 mixhash
-        res = send_json_rpc(self._get_l1_rpc_url(), RPCMethod.GetBlockByNumber, params=[l1_block_number, False])
+        res = send_json_rpc(l1_rpc_url, RPCMethod.GetBlockByNumber, params=[l1_block_number, False])
         prevRandao = res['mixHash']
-
         # 4. encode txs
         encoded_txs = []
 
@@ -156,8 +160,14 @@ class PayloadBuilder:
         if int(l2_block['timestamp'], 16) >= self.canyon_time:
             payload['withdrawals'] = []
 
+        if n > self.ecotone_block_number:
+            payload['blobGasUsed'] = l2_block['blobGasUsed']
+            payload['excessBlobGas'] = l2_block['excessBlobGas']
+
+        payloadArray = [payload, [], l2_block['parentBeaconBlockRoot']]
+
         with open(payload_file, 'w') as f:
-            json.dump(payload, f)
+            json.dump(payloadArray, f)
 
         return True
 

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     print(f'Target safe block: {safe_number}')
     print(f'Target finalized block: {finalized_number}')
 
-    payload_builder = PayloadBuilder(args.payload_dir, args.l1_rpc_urls, args.l2_rpc_urls, args.canyon_time, args.logging)
+    payload_builder = PayloadBuilder(args.payload_dir, args.l1_rpc_urls, args.l2_rpc_urls, args.canyon_time, args.ecotone_time, args.logging)
     payload_applier = PayloadApplier(
         args.engine_url,
         args.jwt_secret,
@@ -41,6 +41,7 @@ if __name__ == '__main__':
         finalized_number,
         finalized_hash,
         args.canyon_time,
+        args.ecotone_time,
         args.logging
     )
 

--- a/utils.py
+++ b/utils.py
@@ -42,5 +42,6 @@ def parse_args():
     parser.add_argument('--jwt-secret', dest='jwt_secret', default='./jwt-secret.txt')
     parser.add_argument('--num-proc', dest='num_proc', default=32, type=int)
     parser.add_argument('--logging', action='store_true', default=False)
+    parser.add_argument('--ecotone-block-number', dest='ecotone_block_number', default=0, type=int)
     parser.add_argument('--canyon-time', dest='canyon_time', default=0, type=int)
     return parser.parse_args()

--- a/utils.py
+++ b/utils.py
@@ -42,6 +42,6 @@ def parse_args():
     parser.add_argument('--jwt-secret', dest='jwt_secret', default='./jwt-secret.txt')
     parser.add_argument('--num-proc', dest='num_proc', default=32, type=int)
     parser.add_argument('--logging', action='store_true', default=False)
-    parser.add_argument('--ecotone-block-number', dest='ecotone_block_number', default=0, type=int)
     parser.add_argument('--canyon-time', dest='canyon_time', default=0, type=int)
+    parser.add_argument('--ecotone-time', dest='ecotone_time', default=0, type=int)
     return parser.parse_args()


### PR DESCRIPTION
In the ecotone release, L1 attributes in the transaction data is updated with different calldata layout: [ref](https://specs.optimism.io/protocol/deposits.html#l1-attributes---ecotone)

To make the payload builder be compatible with this new layout, this PR fixes the code to properly fetch the L1 block from the L2 transaction data. 